### PR TITLE
WIP Field groups implementation

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -83,3 +83,29 @@ export interface FieldConfig<
   /** @deprecated Starting touched state. */
   readonly initialTouched?: boolean;
 }
+
+export interface FieldGroupConfig<
+  S = any,
+  K extends (keyof S & string) | string = S extends Record<string, any>
+    ? keyof S & string
+    : string,
+  V = S extends Record<string, any> ? S[K] : S,
+  F = S extends Record<string, any> ? S : unknown
+> {
+  /** Unique identifier for field group. */
+  readonly name: K;
+  /** Validation function for group (throws errors). */
+  readonly validate?: (value: V, form: F) => void;
+  /** When the given group's value changes. */
+  readonly validateOnChange?: boolean;
+  /** When any change is made to the form state (global). */
+  readonly validateOnUpdate?: boolean;
+  /** Starting value. */
+  readonly initialValue?: V | [];
+  /** Starting error. */
+  readonly initialError?: FormError;
+  /** Starting valid state. */
+  readonly initialValid?: boolean;
+  /** Should destroy value when useFieldGroup hook is unmounted. */
+  readonly destroyOnUnmount?: boolean;
+}

--- a/src/useFieldGroup.spec.tsx
+++ b/src/useFieldGroup.spec.tsx
@@ -1,0 +1,155 @@
+import React, { FC } from 'react';
+import { mount } from 'enzyme';
+import { useFieldGroup } from './useFieldGroup';
+import { FielderContext } from './context';
+import { FieldConfig } from './types';
+import { act } from 'react-dom/test-utils';
+
+let context = {
+  fields: {},
+  mountField: jest.fn(),
+  unmountField: jest.fn(),
+  blurField: jest.fn(),
+  setFieldValue: jest.fn(),
+};
+let response: ReturnType<typeof useFieldGroup>;
+let args: FieldConfig<any> = {} as any;
+
+const F: FC = ({ children }) => {
+  response = useFieldGroup(args);
+
+  return <>{children}</>;
+};
+
+const Fixture: FC = ({ children }) => {
+  return (
+    <FielderContext.Provider value={context as any}>
+      <F>{children}</F>
+    </FielderContext.Provider>
+  );
+};
+
+beforeEach(jest.clearAllMocks);
+
+beforeEach(() => {
+  context = {
+    fields: {},
+    mountField: jest.fn(),
+    unmountField: jest.fn(),
+    blurField: jest.fn(),
+    setFieldValue: jest.fn(),
+  };
+});
+
+describe.skip('initial call', () => {
+  it('matches snapshot', () => {
+    mount(<Fixture />);
+    expect(response).toMatchSnapshot();
+  });
+});
+
+describe('on mount', () => {
+  describe('on first mount', () => {
+    it('calls mount field with default value', () => {
+      args = { name: 'someField' };
+      mount(<Fixture />);
+
+      expect(context.mountField).toBeCalledTimes(1);
+      expect(context.mountField).toBeCalledWith({
+        name: args.name,
+        initialError: undefined,
+        initialValid: true,
+        initialValue: [],
+        validate: undefined,
+        validateOnBlur: true,
+        validateOnChange: true,
+        validateOnUpdate: false,
+      });
+    });
+
+    it('calls mount field with default overrides', () => {
+      args = { name: 'someField', initialValue: [{ age: 50 }] };
+      mount(<Fixture />);
+
+      expect(context.mountField).toBeCalledTimes(1);
+      expect(context.mountField).toBeCalledWith({
+        name: args.name,
+        initialError: undefined,
+        initialValid: true,
+        initialValue: [{ age: 50 }],
+        validate: undefined,
+        validateOnBlur: true,
+        validateOnChange: true,
+        validateOnUpdate: false,
+      });
+    });
+
+    it('matches snapshot', () => {
+      args = { name: 'someField' };
+      mount(<Fixture />);
+
+      expect(response).toMatchInlineSnapshot(`
+        Object {
+          "fields": Object {},
+          "mountField": [Function],
+        }
+      `);
+    });
+  });
+
+  describe.only('on remount', () => {
+    beforeEach(() => {
+      args = { name: 'someField' };
+      context = {
+        ...context,
+        fields: {
+          [args.name]: {
+            value: [
+              { height: 200, age: 30 },
+              { height: 186, age: 46 },
+            ],
+          },
+        },
+      };
+    });
+
+    it('matches snapshot', () => {
+      mount(<Fixture />);
+      expect(response).toMatchInlineSnapshot(`
+        Object {
+          "fields": Object {
+            "0.age": 30,
+            "0.height": 200,
+            "1.age": 46,
+            "1.height": 186,
+          },
+          "mountField": [Function],
+        }
+      `);
+    });
+  });
+});
+
+describe.skip('on field mount', () => {
+  beforeEach(() => {
+    mount(<Fixture />);
+  });
+
+  it('returns an indexed names', () => {
+    const a = 'fieldA';
+    const b = 'fieldB';
+
+    act(() => {
+      expect(response.mountField({ name: a })).toEqual(`0.${a}`);
+    });
+    act(() => {
+      expect(response.mountField({ name: b })).toEqual(`0.${b}`);
+    });
+    act(() => {
+      expect(response.mountField({ name: a })).toEqual(`1.${a}`);
+    });
+    act(() => {
+      expect(response.mountField({ name: b })).toEqual(`1.${b}`);
+    });
+  });
+});

--- a/src/useFieldGroup.ts
+++ b/src/useFieldGroup.ts
@@ -1,0 +1,174 @@
+import { useFormContext, FielderContext } from './context';
+import {
+  FieldGroupConfig,
+  FieldsState,
+  FormState,
+  FieldState,
+  FieldConfig,
+} from './types';
+import {
+  FormAction,
+  applyActionToState,
+  createHandleAsyncValidation,
+  applyValidationToState,
+} from './useForm';
+import {
+  useRef,
+  useMemo,
+  useCallback,
+  Dispatch,
+  useReducer,
+  Reducer,
+  useLayoutEffect,
+  useContext,
+} from 'react';
+
+export const useFieldGroup = <T = any>({
+  name: initialName,
+  validate,
+  initialValid = !validate,
+  initialError = undefined,
+  initialValue = [] as any,
+  validateOnBlur = true,
+  validateOnChange = true,
+  validateOnUpdate = false,
+  destroyOnUnmount = false,
+}: FieldConfig<T>) => {
+  const fieldsRef = useRef<FieldsState<T>>({});
+  const destroyRef = useRef(destroyOnUnmount);
+  const keyRef = useRef<Record<string, number>>({});
+  const dispatchRef = useRef<Dispatch<FormAction<T>>>();
+  const form = useContext(FielderContext);
+
+  const name = useMemo(() => initialName, []);
+
+  useMemo(() => (destroyRef.current = destroyOnUnmount), [destroyOnUnmount]);
+
+  const handleAsyncValidation = useMemo(
+    () => createHandleAsyncValidation(dispatchRef),
+    []
+  );
+
+  const field = useMemo(
+    () =>
+      form.fields[name] || {
+        name,
+        error: initialError,
+        valid: initialValid,
+        value: initialValue,
+        hasBlurred: false,
+        hasChanged: false,
+      },
+    [form.fields, name]
+  );
+
+  useLayoutEffect(() => {
+    if (form.fields[name] && form.fields[name]._isActive) {
+      console.warn(
+        'Fielder warning: Duplicate field mounted.\nSee this issue for more info https://github.com/andyrichardson/fielder/issues/44'
+      );
+    }
+
+    form.mountField({
+      name,
+      initialError,
+      initialValid,
+      initialValue,
+      validate,
+      validateOnBlur,
+      validateOnChange,
+      validateOnUpdate,
+    } as any);
+
+    return () => form.unmountField({ name, destroy: destroyRef.current });
+  }, []);
+
+  const incrementKey = useCallback((name: string) => {
+    if (keyRef.current[name] === undefined) {
+      keyRef.current[name] = 0;
+      return keyRef.current[name];
+    }
+
+    return ++keyRef.current[name];
+  }, []);
+
+  const initialLocalValue = useMemo(() => {
+    if (!Array.isArray(field.value)) {
+      return [];
+    }
+
+    return field.value.reduce(
+      (p, c) => ({
+        ...p,
+        ...Object.keys(c).reduce(
+          (pp, key) => ({
+            ...pp,
+            [`${incrementKey(key)}.${key}`]: c[key],
+          }),
+          {}
+        ),
+      }),
+      {}
+    );
+  }, []);
+
+  const [fields, dispatch] = useReducer<Reducer<FieldsState<T>, FormAction<T>>>(
+    (state, action) => {
+      const newState = applyActionToState(state, action);
+
+      return applyValidationToState(newState, action, handleAsyncValidation);
+    },
+    initialLocalValue
+  );
+
+  useMemo(() => (fieldsRef.current = fields), [fields]);
+
+  const mountField = useCallback<FormState<T>['mountField']>(
+    ({ name, ...config }) => {
+      if (!keyRef.current[name]) {
+        keyRef.current[name] = 0;
+      }
+
+      const newName = `${keyRef.current[name]++}.${name}`;
+      dispatch({
+        type: 'MOUNT_FIELD',
+        config: { ...config, name: newName } as any,
+      });
+      return newName;
+    },
+    [dispatch]
+  );
+
+  const unmountField = useCallback<FormState<T>['unmountField']>(
+    (config) => dispatch({ type: 'UNMOUNT_FIELD', config }),
+    [dispatch]
+  );
+
+  const setFieldValue = useCallback<FormState<T>['setFieldValue']>(
+    (config) => dispatch({ type: 'SET_FIELD_VALUE', config }),
+    [dispatch]
+  );
+
+  const blurField = useCallback<FormState<T>['blurField']>(
+    (config) => dispatch({ type: 'BLUR_FIELD', config: config as any }),
+    [dispatch]
+  );
+
+  const validateField = useCallback<FormState<T>['validateField']>(
+    (config) => dispatch({ type: 'VALIDATE_FIELD', config }),
+    [dispatch]
+  );
+
+  const isValid = useMemo(
+    () => (Object.values(fields) as FieldState[]).every((f) => f.isValid),
+    [fields]
+  );
+
+  return useMemo(
+    () => ({
+      fields,
+      mountField,
+    }),
+    [mountField, fields]
+  );
+};

--- a/src/useForm.ts
+++ b/src/useForm.ts
@@ -51,7 +51,7 @@ interface SetFieldStateAction<T = any> {
   config: SetFieldStateArgs<T>;
 }
 
-type FormAction<T = any> =
+export type FormAction<T = any> =
   | MountFieldAction<T>
   | UnmountFieldAction<T>
   | SetFieldValueAction<T>
@@ -116,6 +116,7 @@ export const useForm = <T = any>(): FormState<T> => {
       ) as FieldState[],
     [fields]
   );
+
   const isValid = useMemo(() => mountedFields.every((f) => f.isValid), [
     mountedFields,
   ]);
@@ -142,7 +143,7 @@ export const useForm = <T = any>(): FormState<T> => {
 };
 
 /** Triggers primary action to state. */
-const applyActionToState = (s: FieldsState, a: FormAction) => {
+export const applyActionToState = (s: FieldsState, a: FormAction) => {
   if (a.type === 'MOUNT_FIELD') {
     return doMountField(s)(a.config);
   }
@@ -167,7 +168,7 @@ const applyActionToState = (s: FieldsState, a: FormAction) => {
 };
 
 /** Tracks async validation and updates state on completion. */
-const createHandleAsyncValidation = <T>(
+export const createHandleAsyncValidation = <T>(
   dispatch: MutableRefObject<Dispatch<FormAction<T>> | undefined>
 ) => {
   let promises: Record<string, number> = {};
@@ -216,7 +217,7 @@ const createHandleAsyncValidation = <T>(
 };
 
 /** Triggers validation on fields items. */
-const applyValidationToState = (
+export const applyValidationToState = (
   state: FieldsState,
   action: FormAction,
   handleAsyncValidation: (name: any, promise: Promise<any>) => void


### PR DESCRIPTION
## About

Fix #219 

### Notes

Adds middleware for translating group logic into a flat structure that fielder can understand.

```tsx
// Inside a Fielder context
const GroupExample = () => {
  const group = useFieldGroup();

  return (
    <FieldGroupProvider value={group}>
      <Child />
      <Child />
      <Child />
    </FieldGroupProvider>
  );
}

const Child = () => {
  const [fieldProps, fieldMeta] = useField({ name: '1234' }) // Same API

  //...
}
```

### Todo

 - [ ] Add group validation function which executes validation argument to `useFieldGroup` and also throws errors if any errors exist in the field group state (blocked by #235).
 - [ ] Update `mountField` fns in all contexts to return name of field
 - [ ] Add `useFieldGroupContext() || useFormContext()` logic to `useField`
 - [ ] Add example
 - [ ] Add documentation